### PR TITLE
Update README.rst to reflect release of Twisted 14.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Starting with version 14.0.0, Twisted will support ephemeral Diffie-Hellman ciph
 Since *pem* just passes keyword arguments to ``CertificateOptions`` verbatim, that will just work.
 
 However, *pem* is also forward compatible.
-Twisted 14.0.0 is not released yet, but *pem* lets you use the API described above anyway.
+If your version of Twisted predates 14.0.0, *pem* lets you use the API described above anyway.
 You can just use ``pem.DiffieHellmanParameters``: if your version of Twisted comes with that class, you just get the Twisted version; if it doesn't, you get a version from *pem*.
 
 Just pass instances of that class as ``dhParameters`` to ``certificateOptionsFromFiles``, and *pem* will make it magically work:


### PR DESCRIPTION
Update docs to reflect that Twisted 14.0.0 has been released.
